### PR TITLE
Enable secret creation when a credentials.password is set

### DIFF
--- a/chisel/templates/secrets.yaml
+++ b/chisel/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.mode "server") .Values.args.auth .Values.args.fingerprint }}
+{{- if or (eq .Values.mode "server") .Values.args.auth .Values.args.fingerprint .Values.credentials.password }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Fix: when in clientmode and setting credentials.password does not create secret