### PR TITLE
Fix template error when no credentials.password is providaded

### DIFF
--- a/chisel/values.yaml
+++ b/chisel/values.yaml
@@ -16,6 +16,9 @@ image:
   tag: ""
   customRegistry: #registry.myorg.com
 
+credentials:
+  password: ""
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Error:
```
Error: INSTALLATION FAILED: template: chisel/templates/secrets.yaml:1:87: executing "chisel/templates/secrets.yaml" at <.Values.credentials.password>: nil pointer evaluating interface {}.password
```

After fix dry-run installations goes well, tested with:
```
helm install chisel-tunnel-1 chisel --values test-values-client.yaml --dry-run
```